### PR TITLE
Add docs, restructure rewrite rules, and tests

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -1,111 +1,171 @@
+"""Chain rewriting utility for dash-dot syntax.
+
+Chains are sequences consisting of digits, centered bullets ("\u2022"), and
+dashes.  The :func:`rewrite_step` function applies one rewrite rule at a time
+using the following patterns (where ``n`` and ``m`` denote digits)::
+
+    1. ``•0•m`` → ``•(m+1)``
+    2. ``-0•`` → ``•``
+    3. ``•0-…-0-(k+1)-v•n`` → ``•n-…-n-k-v•n``
+    4. ``•(k+1)-v•n`` → ``n`` copies of ``•k-v`` followed by ``•n``
+
+Several runner functions demonstrate different execution modes, including
+"abridged" modes that skip repetitive expansions.
+"""
+
 import re
+from dataclasses import dataclass
 from typing import List, Optional, Dict, Tuple
+
+
+@dataclass
+class RewriteMatch:
+    """Representation of a single rule match."""
+
+    start: int
+    rule_id: int
+    tokens: List[str]
+
 
 # Normalize input to use centered bullets
 def _normalize(chain: str) -> str:
+    """Replace ASCII dots with the centered bullet character."""
     return chain.replace('.', '•')
+
 
 # Tokenization helpers
 def _tokenize(chain: str) -> List[str]:
+    """Split a chain into digits, bullet symbols, and dashes."""
     return re.findall(r"\d+|[•-]", chain)
 
-def _detokenate(tokens: List[str]) -> str:
+
+def _detokenize(tokens: List[str]) -> str:
+    """Convert a token list back into a chain string."""
     return ''.join(tokens)
 
-# Core rewrite function: smallest-suffix priority
-def rewrite_step(chain: str) -> Optional[str]:
-    tokens = _tokenize(chain)
+
+def _rule1(tokens: List[str]) -> List[RewriteMatch]:
+    """Match Rule 1: ``•0•m → •(m+1)``."""
     n = len(tokens)
-    matches: List[Tuple[int, int, List[str]]] = []
-
-    # Rule 1: •0•m → •(m+1)
+    matches: List[RewriteMatch] = []
     for i in range(n - 3):
-        if (tokens[i] == '•' and tokens[i+1] == '0' and tokens[i+2] == '•'
-                and tokens[i+3].isdigit()):
-            m_val = int(tokens[i+3])
-            new = tokens[:i] + ['•', str(m_val + 1)] + tokens[i+4:]
-            matches.append((i, 1, new))
+        if (
+            tokens[i] == '•'
+            and tokens[i + 1] == '0'
+            and tokens[i + 2] == '•'
+            and tokens[i + 3].isdigit()
+        ):
+            m_val = int(tokens[i + 3])
+            new = tokens[:i] + ['•', str(m_val + 1)] + tokens[i + 4:]
+            matches.append(RewriteMatch(i, 1, new))
+    return matches
 
-    # Rule 2: -0• → •
+
+def _rule2(tokens: List[str]) -> List[RewriteMatch]:
+    """Match Rule 2: ``-0• → •``."""
+    n = len(tokens)
+    matches: List[RewriteMatch] = []
     for i in range(n - 2):
-        if tokens[i] == '-' and tokens[i+1] == '0' and tokens[i+2] == '•':
-            new = tokens[:i] + ['•'] + tokens[i+3:]
-            matches.append((i, 2, new))
+        if tokens[i] == '-' and tokens[i + 1] == '0' and tokens[i + 2] == '•':
+            new = tokens[:i] + ['•'] + tokens[i + 3:]
+            matches.append(RewriteMatch(i, 2, new))
+    return matches
 
-    # Rule 3: •0-…-0-(k+1)-v•n → •n-…-n-k-v•n
+
+def _rule3(tokens: List[str]) -> List[RewriteMatch]:
+    """Match Rule 3 as described in the module summary."""
+    n = len(tokens)
+    matches: List[RewriteMatch] = []
     for i in range(n):
         if tokens[i] != '•':
             continue
-        for j in range(i+1, n):
+        for j in range(i + 1, n):
             if tokens[j] != '•':
                 continue
-            inner = tokens[i+1:j]
+            inner = tokens[i + 1 : j]
             if len(inner) < 3:
                 continue
-            # count leading zero-dash pairs
             zeros = 0
             idx_inner = 0
-            while (idx_inner+1 < len(inner)
-                   and inner[idx_inner] == '0'
-                   and inner[idx_inner+1] == '-'):
+            while (
+                idx_inner + 1 < len(inner)
+                and inner[idx_inner] == '0'
+                and inner[idx_inner + 1] == '-'
+            ):
                 zeros += 1
                 idx_inner += 2
             if zeros == 0:
                 continue
-            # match k+1
             if idx_inner >= len(inner) or not inner[idx_inner].isdigit():
                 continue
             kp1 = int(inner[idx_inner])
             k = kp1 - 1
-            # ensure suffix bullet n
-            if j+1 >= n or not tokens[j+1].isdigit():
+            if j + 1 >= n or not tokens[j + 1].isdigit():
                 continue
-            n_val = int(tokens[j+1])
-            # extract v_tokens
-            v_tokens = inner[idx_inner+1:]
+            n_val = int(tokens[j + 1])
+            v_tokens = inner[idx_inner + 1 :]
             valid_v = True
             for t in range(0, len(v_tokens), 2):
-                if not (v_tokens[t] == '-' and t+1 < len(v_tokens)
-                        and v_tokens[t+1].isdigit()):
+                if not (
+                    v_tokens[t] == '-' and t + 1 < len(v_tokens) and v_tokens[t + 1].isdigit()
+                ):
                     valid_v = False
                     break
             if not valid_v:
                 continue
-            # build new prefix
             prefix = ['•', str(n_val)]
-            for _ in range(zeros-1):
+            for _ in range(zeros - 1):
                 prefix += ['-', str(n_val)]
             prefix += ['-', str(k)]
-            new = tokens[:i] + prefix + v_tokens + ['•', str(n_val)] + tokens[j+2:]
-            matches.append((i, 3, new))
+            new = tokens[:i] + prefix + v_tokens + ['•', str(n_val)] + tokens[j + 2 :]
+            matches.append(RewriteMatch(i, 3, new))
+    return matches
 
-    # Rule 4: •(k+1)-v•n → n copies of •k-v, then •n
+
+def _rule4(tokens: List[str]) -> List[RewriteMatch]:
+    """Match Rule 4 as described in the module summary."""
+    n = len(tokens)
+    matches: List[RewriteMatch] = []
     for i in range(n - 2):
-        if tokens[i] == '•' and tokens[i+1].isdigit():
-            k = int(tokens[i+1]) - 1
+        if tokens[i] == '•' and tokens[i + 1].isdigit():
+            k = int(tokens[i + 1]) - 1
             j = i + 2
             v_tokens: List[str] = []
-            while j+1 < n and tokens[j] == '-' and tokens[j+1].isdigit():
-                v_tokens += [tokens[j], tokens[j+1]]
+            while j + 1 < n and tokens[j] == '-' and tokens[j + 1].isdigit():
+                v_tokens += [tokens[j], tokens[j + 1]]
                 j += 2
-            if j < n and tokens[j] == '•' and tokens[j+1].isdigit():
-                n_copies = int(tokens[j+1])
+            if j < n and tokens[j] == '•' and tokens[j + 1].isdigit():
+                n_copies = int(tokens[j + 1])
                 rep: List[str] = []
                 for _ in range(n_copies):
                     rep += ['•', str(k)] + v_tokens
-                new = tokens[:i] + rep + ['•', str(n_copies)] + tokens[j+2:]
-                matches.append((i, 4, new))
+                new = tokens[:i] + rep + ['•', str(n_copies)] + tokens[j + 2 :]
+                matches.append(RewriteMatch(i, 4, new))
+    return matches
+
+
+# Core rewrite function: smallest-suffix priority
+def rewrite_step(chain: str) -> Optional[str]:
+    """Return the next chain after applying one rewrite rule, if any."""
+    tokens = _tokenize(chain)
+    matches: List[RewriteMatch] = []
+    matches.extend(_rule1(tokens))
+    matches.extend(_rule2(tokens))
+    matches.extend(_rule3(tokens))
+    matches.extend(_rule4(tokens))
 
     if not matches:
         return None
-    # choose rewrite on smallest suffix (max start index), then lowest rule_id
-    max_i = max(m[0] for m in matches)
-    candidates = [m for m in matches if m[0] == max_i]
-    candidates.sort(key=lambda m: m[1])
-    return _detokenate(candidates[0][2])
+
+    max_i = max(m.start for m in matches)
+    candidates = [m for m in matches if m.start == max_i]
+    candidates.sort(key=lambda m: m.rule_id)
+    return _detokenize(candidates[0].tokens)
 
 # Standard runners
 def run_verbose(chain: str) -> None:
+    """Print each intermediate chain produced during rewriting."""
+
     cur = chain
     print(cur)
     steps = 0
@@ -119,6 +179,8 @@ def run_verbose(chain: str) -> None:
     print(f"Total steps: {steps}")
 
 def run_last(chain: str) -> None:
+    """Run until no rule applies and print only the final chain."""
+
     cur = chain
     steps = 0
     while True:
@@ -131,6 +193,8 @@ def run_last(chain: str) -> None:
         cur = nxt
 
 def run_interactive(chain: str) -> None:
+    """Like :func:`run_verbose` but waits for input between steps."""
+
     cur = chain
     print(cur)
     steps = 0
@@ -144,8 +208,11 @@ def run_interactive(chain: str) -> None:
         cur = nxt
     print(f"Total steps: {steps}")
 
+
 # Abridged runners with streaming omissions and memoization
 def run_abridged(chain: str) -> None:
+    """Run with heuristics to omit large expansions while streaming output."""
+
     cur = chain
     print(cur)
     steps = 0
@@ -213,7 +280,10 @@ def run_abridged(chain: str) -> None:
         cur = nxt
     print(f"Total steps: {steps}")
 
+
 def interactive_abridged(chain: str) -> None:
+    """Interactive variant of :func:`run_abridged`."""
+
     cur = chain
     print(cur)
     steps = 0
@@ -288,7 +358,7 @@ if __name__ == '__main__':
             'step', 'run', 'interactive', 'last',
             'run_abridged', 'interactive_abridged'):
         print(
-            "Usage: python chain_rewriter.py"
+            "Usage: python chain.py"
             " [step|run|interactive|last|run_abridged|interactive_abridged] '<chain>'"
         )
         sys.exit(1)

--- a/test_chain.py
+++ b/test_chain.py
@@ -1,0 +1,21 @@
+import unittest
+import chain
+
+class TestRewriteStep(unittest.TestCase):
+    def test_rule1(self):
+        self.assertEqual(chain.rewrite_step('•0•3'), '•4')
+
+    def test_rule2(self):
+        self.assertEqual(chain.rewrite_step('-0•'), '•')
+
+    def test_rule3(self):
+        self.assertEqual(
+            chain.rewrite_step('•0-0-3-5•2'),
+            '•2-2-2-5•2'
+        )
+
+    def test_rule4(self):
+        self.assertEqual(chain.rewrite_step('•3-5•2'), '•2-5•2-5•2')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve module documentation and function docstrings
- rename `_detokenate` helper to `_detokenize`
- extract rewrite rules into helper functions
- clean up spacing and update CLI usage instructions
- add a small test suite to cover all rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d29484288325b27eef29d4b1fec9